### PR TITLE
Remove version dependencies

### DIFF
--- a/MLHUB.yaml
+++ b/MLHUB.yaml
@@ -3,7 +3,7 @@ meta:
   name      : facedetect
   title     : Simple face detection.
   languages : py
-  version   : 0.2.5
+  version   : 0.2.6
   keywords  : face detection, python3, computer vision
   license   : gpl3
   display   : demo, score, live

--- a/MLHUB.yaml
+++ b/MLHUB.yaml
@@ -13,8 +13,8 @@ dependencies:
     - matplotlib
     - toolz
   pip3:
-    - opencv-contrib-python==4.0.0.21
-    - numpy==1.14.5
+    - opencv-contrib-python
+    - numpy
   files:
     - demo.py
     - utils.py


### PR DESCRIPTION
Specific versions for opencv and numpy not required - and in fact the specific versions have gone missing.